### PR TITLE
Use MadgwickAHRS 

### DIFF
--- a/include/imu.h
+++ b/include/imu.h
@@ -16,16 +16,24 @@ bool imuIsEnabled();
 void imuInit(uint8_t addr, TwoWire *theWire);
 void imuCalibrate(unsigned long calibrationTime);
 
-bool imuPeriodic();
+void imuPeriodic();
+bool imuDataReady();
 
-float gyroGetAngleX();
-float gyroGetRateX();
+float imuGetAccelX();
+float imuGetAccelY();
+float imuGetAccelZ();
 
-float gyroGetAngleY();
-float gyroGetRateY();
+float imuGetGyroRateX();
+float imuGetGyroRateY();
+float imuGetGyroRateZ();
 
-float gyroGetAngleZ();
-float gyroGetRateZ();
+float imuGetRoll();
+float imuGetPitch();
+float imuGetYaw();
+
+void imuResetRoll();
+void imuResetPitch();
+void imuResetYaw();
 
 void gyroReset();
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -13,3 +13,4 @@ lib_deps =
     adafruit/Adafruit LSM6DS@^4.7.0
     adafruit/Adafruit BusIO@^1.14.1
     adafruit/Adafruit Unified Sensor@^1.1.9
+    arduino-libraries/Madgwick@^1.2.0

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -160,6 +160,9 @@ void loop() {
   // webServer.handleClient();
   wsServer.loop();
 
+  // TODO always run the IMU periodic routine
+  xrp::imuPeriodic();
+
   // Disable the robot when we no longer have a connection
   int numConnectedClients = wsServer.connectedClients();
   if (lastCheckedNumClients > 0 && numConnectedClients == 0) {
@@ -188,11 +191,11 @@ void loop() {
     }
 
     // Read Gyro Data
-    if (xrp::imuPeriodic()) {
-      float rateZ = xrp::gyroGetRateZ();
-      float angleZ = xrp::gyroGetAngleZ();
+    if (xrp::imuDataReady()) {
+      float rateZ = xrp::imuGetGyroRateZ();
+      float yawAngle = xrp::imuGetYaw();
       
-      sendMessage(wpilibws::makeGyroSingleMessage(wpilibws::AXIS_Z, rateZ, angleZ));
+      sendMessage(wpilibws::makeGyroSingleMessage(wpilibws::AXIS_Z, rateZ, yawAngle));
     }
 
   }


### PR DESCRIPTION
This PR uses the Madgwick filter to implement an AHRS (Attitude and Heading Reference System) and return the filtered RPY values instead of raw gyro angles. Combined with the gyro calibration in #10, this provides a more stable angle reading.

Fixes #9 